### PR TITLE
Sean/activities

### DIFF
--- a/logic/activitiesLogic.js
+++ b/logic/activitiesLogic.js
@@ -87,8 +87,6 @@ const addToActivities = async (
 	try {
 		//if genesis minting (NFT transfers)
 		if (transactionType === "genesisMinting") {
-			console.log("genesisMinting activity");
-
 			const ethNFTTransfers = Moralis.Object.extend("EthNFTTransfers");
 			const ethNFTQuery = new Moralis.Query(ethNFTTransfers);
 
@@ -122,7 +120,6 @@ const addToActivities = async (
 		} else {
 			// Only for hatching activity (for now)
 			// Will be called from Frontend because hatching is done from there
-			console.log("hatch activity");
 
 			const hatchingKey = await checkHatchingKeyValid(transactionHash);
 

--- a/logic/activitiesLogic.js
+++ b/logic/activitiesLogic.js
@@ -1,19 +1,20 @@
 const moment = require("moment");
 const Moralis = require("moralis/node");
 
+const InputDataDecoder = require("ethereum-input-data-decoder");
+const genesisNBMonABI = require(`${__dirname}/../abi/genesisNBMon.json`);
+const decoder = new InputDataDecoder(genesisNBMonABI);
+
 const getUserActivities = async (address) => {
 	//At the moment, this only gets the user's activities where they receive (buy / mint) NFTs
+	//and when user hatches the egg
 	try {
-		const nftTransfers = Moralis.Object.extend("NFTTransfers");
-		const nftTranfersQuery = new Moralis.Query(nftTransfers);
+		const activities = Moralis.Object.extend("UserTransactionsActivities");
+		const activitiesQuery = new Moralis.Query(activities);
 
-		//In the future, to get the full user's activities,
-		//the query should be improved to also query for address_from user's address
-		//and possibly other things as well if needed.
+		activitiesQuery.equalTo("address_activity_owner", address.toLowerCase());
 
-		nftTranfersQuery.equalTo("address_to", address.toLowerCase());
-
-		const queryResult = await nftTranfersQuery.find({ useMasterKey: true });
+		const queryResult = await activitiesQuery.find({ useMasterKey: true });
 		let jsonQueryResult = JSON.parse(JSON.stringify(queryResult));
 
 		return groupByDate(jsonQueryResult);
@@ -22,10 +23,10 @@ const getUserActivities = async (address) => {
 	}
 };
 
-const groupByDate = (jsonQuery) => {
+const groupByDate = (jsonQueryResult) => {
 	let objectStore = {};
 
-	jsonQuery.map((obj) => {
+	jsonQueryResult.map((obj) => {
 		const groupByDateWithoutTime = `${moment(
 			new Date(obj.timestamp.iso)
 		).format("DD")} ${moment(new Date(obj.timestamp.iso)).format(
@@ -61,6 +62,22 @@ const groupByDate = (jsonQuery) => {
 		.reverse(); // return grouped by its date - this is to fulfil the frontend's (UI) requirement
 };
 
+/**
+ * @dev Saves newly generated hatching key to DB
+ * This key is to be checked later after the hatching has finished.
+ * It's a part of adding a "hatching event" to the user's activities.
+ * See addToActivities(), checkHatchingKeyValid() & invalidateHatchingKey().
+ */
+
+const saveHatchingKey = async (key) => {
+	const hatchingKeys = Moralis.Object.extend("HatchingKeys");
+	const newHatchingKey = new hatchingKeys();
+	newHatchingKey.set("key", key);
+	newHatchingKey.set("addedToActivity", false);
+
+	await newHatchingKey.save(null, { useMasterKey: true }).catch((err) => err);
+};
+
 const addToActivities = async (
 	transactionHash,
 	transactionType,
@@ -68,35 +85,156 @@ const addToActivities = async (
 	value
 ) => {
 	try {
-		const ethNFTTransfers = Moralis.Object.extend("EthNFTTransfers");
-		const ethNFTQuery = new Moralis.Query(ethNFTTransfers);
+		//if genesis minting (NFT transfers)
+		if (transactionType === "genesisMinting") {
+			console.log("genesisMinting activity");
 
-		ethNFTQuery.equalTo("transaction_hash", transactionHash);
-		const queryResult = await ethNFTQuery.first({ useMasterKey: true });
+			const ethNFTTransfers = Moralis.Object.extend("EthNFTTransfers");
+			const ethNFTQuery = new Moralis.Query(ethNFTTransfers);
 
-		const jsonResult = JSON.parse(JSON.stringify(queryResult));
-		const { from_address, to_address, block_timestamp } = jsonResult;
+			ethNFTQuery.equalTo("transaction_hash", transactionHash);
+			const queryResult = await ethNFTQuery.first({ useMasterKey: true });
 
-		//insert into our custom-made Class "NFTTransfers", so can be displayed as activities in the frontend
-		const NFTTransfer = Moralis.Object.extend("NFTTransfers");
-		const newTransfer = new NFTTransfer();
+			const jsonResult = JSON.parse(JSON.stringify(queryResult));
+			const { from_address, to_address, block_timestamp } = jsonResult;
 
-		newTransfer.set("address_from", from_address);
-		newTransfer.set("address_to", to_address);
-		newTransfer.set("transaction_hash", transactionHash);
-		newTransfer.set("transaction_type", transactionType);
-		newTransfer.set("network", network);
-		newTransfer.set("value", value.toString());
-		newTransfer.set("timestamp", block_timestamp);
+			//insert into our custom-made Class "UserTransactionsActivities", so can be displayed as activities in the frontend
+			const NFTTransfer = Moralis.Object.extend("UserTransactionsActivities");
+			const newTransfer = new NFTTransfer();
 
-		//Saves using master key (due to CLP being only "read" for only public)
-		await newTransfer.save(null, { useMasterKey: true });
+			//because the NFT transfer is from "us" to the "customer"
+			//so the owner  of this activity (to be displayed in their account)
+			//is the "to" address; which is the "customer"
+
+			newTransfer.set("address_activity_owner", to_address);
+
+			newTransfer.set("address_from", from_address);
+			newTransfer.set("address_to", to_address);
+
+			newTransfer.set("transaction_hash", transactionHash);
+			newTransfer.set("transaction_type", transactionType);
+			newTransfer.set("network", network);
+			newTransfer.set("value", value.toString());
+			newTransfer.set("timestamp", block_timestamp);
+
+			//Saves using master key (due to CLP being only "read" for only public)
+			await newTransfer.save(null, { useMasterKey: true });
+		} else {
+			// Only for hatching activity (for now)
+			// Will be called from Frontend because hatching is done from there
+			console.log("hatch activity");
+
+			const hatchingKey = await checkHatchingKeyValid(transactionHash);
+
+			const { valid, data, decodedKey } = hatchingKey;
+
+			if (valid) {
+				const { from_address, to_address, block_timestamp } = data;
+				//insert into our custom-made Class "UserTransactionsActivities", so can be displayed as activities in the frontend
+				const activity = Moralis.Object.extend("UserTransactionsActivities");
+				const newActivity = new activity();
+
+				newActivity.set("address_activity_owner", from_address);
+
+				newActivity.set("address_from", from_address);
+				newActivity.set("address_to", to_address);
+				newActivity.set("transaction_hash", transactionHash);
+				newActivity.set("transaction_type", transactionType);
+				newActivity.set("network", network);
+				newActivity.set("value", value.toString());
+				newActivity.set("timestamp", block_timestamp);
+
+				//Saves using master key (due to CLP being only "read" for only public)
+				await newActivity
+					.save(null, { useMasterKey: true })
+					.catch((err) => err);
+
+				await invalidateHatchingKey(decodedKey);
+
+				return { status: "ok", message: "activity added" };
+			} else {
+				throw new Error("Hatching key is invalid");
+			}
+		}
 	} catch (err) {
-		return err;
+		throw new Error(err.stack);
 	}
+};
+
+/**
+ * @dev Checks if hatching key is valid
+ * Valid means:
+ * 1. an egg has been hatched with that key and,
+ * 2. this hatching "event" hasn't been added to the user's activity
+ */
+
+const checkHatchingKeyValid = async (hash) => {
+	const ethTransactions = Moralis.Object.extend("EthTransactions");
+	const ethTransactionQuery = new Moralis.Query(ethTransactions);
+	ethTransactionQuery.equalTo("hash", hash);
+	const queryResult = await ethTransactionQuery.first({ useMasterKey: true });
+
+	if (!queryResult)
+		return {
+			valid: false,
+			data: null,
+			decodedKey: null,
+		};
+
+	const ethTransactionResult = JSON.parse(JSON.stringify(queryResult));
+
+	//Checks from all hatching keys that are valid
+	const hatchingKeys = Moralis.Object.extend("HatchingKeys");
+	const hatchingKeyQuery = new Moralis.Query(hatchingKeys);
+
+	const hatchingKeyFromTransactionInput = decoder.decodeData(
+		ethTransactionResult.input
+	).inputs[0];
+
+	hatchingKeyQuery.equalTo("key", hatchingKeyFromTransactionInput);
+	hatchingKeyQuery.equalTo("addedToActivity", false);
+
+	const hatchingQueryResult = await hatchingKeyQuery.first({
+		useMasterKey: true,
+	});
+
+	if (hatchingQueryResult) {
+		return {
+			valid: true,
+			data: ethTransactionResult,
+			decodedKey: hatchingKeyFromTransactionInput,
+		};
+	}
+	return {
+		valid: false,
+		data: null,
+		decodedKey: null,
+	};
+};
+
+/**
+ * @dev Invalidates hatching key in DB by changing "addedToActivity" field to true
+ * This is to make sure that no same activity can be added twice
+ */
+const invalidateHatchingKey = async (key) => {
+	const hatchingKeys = Moralis.Object.extend("HatchingKeys");
+	const hatchingKeyQuery = new Moralis.Query(hatchingKeys);
+
+	hatchingKeyQuery.equalTo("key", key);
+
+	const hatchingQueryResult = await hatchingKeyQuery.first({
+		useMasterKey: true,
+	});
+
+	if (hatchingQueryResult) {
+		hatchingQueryResult.set("addedToActivity", true);
+	}
+
+	await hatchingQueryResult.save({ useMasterKey: true });
 };
 
 module.exports = {
 	getUserActivities,
 	addToActivities,
+	saveHatchingKey,
 };

--- a/logic/activitiesLogic.js
+++ b/logic/activitiesLogic.js
@@ -183,10 +183,8 @@ const checkHatchingKeyValid = async (hash) => {
 	//Checks from all hatching keys that are valid
 	const hatchingKeys = Moralis.Object.extend("HatchingKeys");
 	const hatchingKeyQuery = new Moralis.Query(hatchingKeys);
-
-	const hatchingKeyFromTransactionInput = decoder.decodeData(
-		ethTransactionResult.input
-	).inputs[0];
+	const decodedInput = decoder.decodeData(ethTransactionResult.input);
+	const hatchingKeyFromTransactionInput = decodedInput.inputs[0];
 
 	hatchingKeyQuery.equalTo("key", hatchingKeyFromTransactionInput);
 	hatchingKeyQuery.equalTo("addedToActivity", false);
@@ -195,7 +193,7 @@ const checkHatchingKeyValid = async (hash) => {
 		useMasterKey: true,
 	});
 
-	if (hatchingQueryResult) {
+	if (hatchingQueryResult && decodedInput.method === "hatchFromEgg") {
 		return {
 			valid: true,
 			data: ethTransactionResult,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"cors": "^2.8.5",
 				"dotenv": "^16.0.0",
+				"ethereum-input-data-decoder": "^0.4.1",
 				"ethers": "^5.6.2",
 				"express": "^4.17.3",
 				"moment": "^2.29.2",
@@ -1363,7 +1364,6 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
 			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1932,6 +1932,267 @@
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/ethereum-input-data-decoder/-/ethereum-input-data-decoder-0.4.1.tgz",
+			"integrity": "sha512-yFsmePyRSEXU5Im9G882TzZI2ZFvJ6RZ2+txQeI3J7OVd7h6/VB+MUzKeL/Yorj7u1ak78NaUhVdyJNj1S3CQQ==",
+			"dependencies": {
+				"@types/node": "^16.7.13",
+				"bn.js": "^4.11.8",
+				"buffer": "^5.2.1",
+				"ethers": "^5.5.4",
+				"is-buffer": "^2.0.3",
+				"meow": "^10.1.1"
+			},
+			"bin": {
+				"ethereum_input_data_decoder": "bin/ethereum_input_data_decoder",
+				"ethereum-input-data-decoder": "bin/ethereum_input_data_decoder"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/@types/node": {
+			"version": "16.11.31",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.31.tgz",
+			"integrity": "sha512-wh/d0pcu/Ie2mqTIqh4tjd0mLAB4JWxOjHQtLN20HS7sjMHiV4Afr+90hITTyZcxowwha5wjv32jGEn1zkEFMg=="
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/buffer": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/camelcase-keys": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+			"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+			"dependencies": {
+				"camelcase": "^6.3.0",
+				"map-obj": "^4.1.0",
+				"quick-lru": "^5.1.1",
+				"type-fest": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/decamelize": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+			"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/meow": {
+			"version": "10.1.2",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.2.tgz",
+			"integrity": "sha512-zbuAlN+V/sXlbGchNS9WTWjUzeamwMt/BApKCJi7B0QyZstZaMx0n4Unll/fg0njGtMdC9UP5SAscvOCLYdM+Q==",
+			"dependencies": {
+				"@types/minimist": "^1.2.2",
+				"camelcase-keys": "^7.0.0",
+				"decamelize": "^5.0.0",
+				"decamelize-keys": "^1.1.0",
+				"hard-rejection": "^2.1.0",
+				"minimist-options": "4.1.0",
+				"normalize-package-data": "^3.0.2",
+				"read-pkg-up": "^8.0.0",
+				"redent": "^4.0.0",
+				"trim-newlines": "^4.0.2",
+				"type-fest": "^1.2.2",
+				"yargs-parser": "^20.2.9"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/quick-lru": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+			"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/read-pkg": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+			"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.0",
+				"normalize-package-data": "^3.0.2",
+				"parse-json": "^5.2.0",
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/read-pkg-up": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+			"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+			"dependencies": {
+				"find-up": "^5.0.0",
+				"read-pkg": "^6.0.0",
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/redent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+			"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+			"dependencies": {
+				"indent-string": "^5.0.0",
+				"strip-indent": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/strip-indent": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+			"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+			"dependencies": {
+				"min-indent": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/trim-newlines": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+			"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ethereum-input-data-decoder/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/ethers": {
@@ -2796,6 +3057,28 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/is-callable": {
@@ -5153,6 +5436,17 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -6081,8 +6375,7 @@
 		"camelcase": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-			"dev": true
+			"integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
 		},
 		"camelcase-keys": {
 			"version": "6.2.2",
@@ -6518,6 +6811,161 @@
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+		},
+		"ethereum-input-data-decoder": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/ethereum-input-data-decoder/-/ethereum-input-data-decoder-0.4.1.tgz",
+			"integrity": "sha512-yFsmePyRSEXU5Im9G882TzZI2ZFvJ6RZ2+txQeI3J7OVd7h6/VB+MUzKeL/Yorj7u1ak78NaUhVdyJNj1S3CQQ==",
+			"requires": {
+				"@types/node": "^16.7.13",
+				"bn.js": "^4.11.8",
+				"buffer": "^5.2.1",
+				"ethers": "^5.5.4",
+				"is-buffer": "^2.0.3",
+				"meow": "^10.1.1"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "16.11.31",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.31.tgz",
+					"integrity": "sha512-wh/d0pcu/Ie2mqTIqh4tjd0mLAB4JWxOjHQtLN20HS7sjMHiV4Afr+90hITTyZcxowwha5wjv32jGEn1zkEFMg=="
+				},
+				"buffer": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"requires": {
+						"base64-js": "^1.3.1",
+						"ieee754": "^1.1.13"
+					}
+				},
+				"camelcase-keys": {
+					"version": "7.0.2",
+					"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
+					"integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+					"requires": {
+						"camelcase": "^6.3.0",
+						"map-obj": "^4.1.0",
+						"quick-lru": "^5.1.1",
+						"type-fest": "^1.2.1"
+					}
+				},
+				"decamelize": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+					"integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA=="
+				},
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"indent-string": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+					"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"meow": {
+					"version": "10.1.2",
+					"resolved": "https://registry.npmjs.org/meow/-/meow-10.1.2.tgz",
+					"integrity": "sha512-zbuAlN+V/sXlbGchNS9WTWjUzeamwMt/BApKCJi7B0QyZstZaMx0n4Unll/fg0njGtMdC9UP5SAscvOCLYdM+Q==",
+					"requires": {
+						"@types/minimist": "^1.2.2",
+						"camelcase-keys": "^7.0.0",
+						"decamelize": "^5.0.0",
+						"decamelize-keys": "^1.1.0",
+						"hard-rejection": "^2.1.0",
+						"minimist-options": "4.1.0",
+						"normalize-package-data": "^3.0.2",
+						"read-pkg-up": "^8.0.0",
+						"redent": "^4.0.0",
+						"trim-newlines": "^4.0.2",
+						"type-fest": "^1.2.2",
+						"yargs-parser": "^20.2.9"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"quick-lru": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+					"integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+				},
+				"read-pkg": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+					"integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+					"requires": {
+						"@types/normalize-package-data": "^2.4.0",
+						"normalize-package-data": "^3.0.2",
+						"parse-json": "^5.2.0",
+						"type-fest": "^1.0.1"
+					}
+				},
+				"read-pkg-up": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+					"integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+					"requires": {
+						"find-up": "^5.0.0",
+						"read-pkg": "^6.0.0",
+						"type-fest": "^1.0.1"
+					}
+				},
+				"redent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+					"integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+					"requires": {
+						"indent-string": "^5.0.0",
+						"strip-indent": "^4.0.0"
+					}
+				},
+				"strip-indent": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+					"integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+					"requires": {
+						"min-indent": "^1.0.1"
+					}
+				},
+				"trim-newlines": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+					"integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew=="
+				},
+				"type-fest": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+				}
+			}
 		},
 		"ethers": {
 			"version": "5.6.2",
@@ -7193,6 +7641,11 @@
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
 			}
+		},
+		"is-buffer": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
 		},
 		"is-callable": {
 			"version": "1.2.4",
@@ -8949,6 +9402,11 @@
 			"version": "20.2.9",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
 			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 	"dependencies": {
 		"cors": "^2.8.5",
 		"dotenv": "^16.0.0",
+		"ethereum-input-data-decoder": "^0.4.1",
 		"ethers": "^5.6.2",
 		"express": "^4.17.3",
 		"moment": "^2.29.2",

--- a/routes/activities.js
+++ b/routes/activities.js
@@ -1,13 +1,37 @@
 const express = require("express");
 const router = express.Router();
-const { getUserActivities } = require("../logic/activitiesLogic");
+const {
+	getUserActivities,
+	addToActivities,
+	saveHatchingKey,
+} = require("../logic/activitiesLogic");
 
 router.get("/:address", async (req, res) => {
 	const { address } = req.params;
-	let activities = await getUserActivities(address).catch((err) =>
-		res.json(err)
-	);
+	let activities = await getUserActivities(address).catch((error) => {
+		return { error: error.message };
+	});
 	res.json(activities);
 });
+router.post("/addHatchingActivity", async (req, res) => {
+	const { hash } = req.body;
 
+	let result = await addToActivities(hash, "genesisHatching", "eth", "0").catch(
+		(error) => {
+			return { error: error.message };
+		}
+	);
+
+	res.json(result);
+});
+
+// router.post("/addKey", async (req, res) => {
+// 	const { key } = req.body;
+
+// 	let result = await saveHatchingKey(key).catch((error) => {
+// 		return { error: error.message };
+// 	});
+
+// 	res.json(result);
+// });
 module.exports = router;

--- a/routes/activities.js
+++ b/routes/activities.js
@@ -3,7 +3,6 @@ const router = express.Router();
 const {
 	getUserActivities,
 	addToActivities,
-	saveHatchingKey,
 } = require("../logic/activitiesLogic");
 
 router.get("/:address", async (req, res) => {
@@ -25,13 +24,4 @@ router.post("/addHatchingActivity", async (req, res) => {
 	res.json(result);
 });
 
-// router.post("/addKey", async (req, res) => {
-// 	const { key } = req.body;
-
-// 	let result = await saveHatchingKey(key).catch((error) => {
-// 		return { error: error.message };
-// 	});
-
-// 	res.json(result);
-// });
 module.exports = router;


### PR DESCRIPTION
Reworked activities logic & routes to be able to correctly add both genesis minting and genesis hatching as users' activities :)

Done by creating a new route + extra validations. **The way of saving genesis minting activity stays the same, so no change there - only genesis hatching's way changed.**

How does saving hatching activity work now?

0. After the backend has generated random stats and key (`/randomizeHatchingStats`), it saves the (hatching) key in a newly created database class/table called `HatchingKeys`, along with a field of `addedToActivity` with a value of `false`

1. Upon successful hatching transaction (from the FE), FE calls the newly created endpoint `/addHatchingActivity` by sending a POST request along with the transaction hash of that hatching transaction.

2. In this endpoint the hash will be checked to get the (hatching) key that's tied to that hash. Key is taken from decoded transaction's input, this data is fetched from `EthTransactions` class.

3. If the key retrieved from 2 exists in the `HatchingKeys` class AND `addedToActivity` is false, **this means the key is valid, and finally the activity will be added for that user** (user is taken from the transaction, to be more precise it's the `address_from`).

4. After 3 is done, the key gets invalidated by changing the `addedToActivity` field of that key (in `HatchingKeys` class) to be `true`

5. If the key is invalid, then obviously no activity will be added :)
