### PR TITLE
new minting policy /config fix

### DIFF
--- a/logic/genesisMetadataLogic.js
+++ b/logic/genesisMetadataLogic.js
@@ -29,7 +29,7 @@ const uploadGenesisEggMetadata = (id, hatchingDuration) => {
 			{
 				display_type: "date",
 				trait_type: "Born on",
-                // born on may be slightly different than the smart contract's bornAt due to the nature of the code.
+				// born on may be slightly different than the smart contract's bornAt due to the nature of the code.
 				value: moment().unix(),
 			},
 			{
@@ -40,7 +40,7 @@ const uploadGenesisEggMetadata = (id, hatchingDuration) => {
 		],
 	};
 
-    // creates a new object in the bucket
+	// creates a new object in the bucket
 	s3.putObject(
 		{
 			Bucket: process.env.SPACES_NAME,
@@ -50,163 +50,165 @@ const uploadGenesisEggMetadata = (id, hatchingDuration) => {
 			ContentType: "application/json",
 		},
 		(err) => {
+			if (err) console.log("ERROR s3 upload", err);
 			if (err) throw new Error(err.stack);
-			return `genesisNBMon/${id}.json has been successfully created.`
+			return `genesisNBMon/${id}.json has been successfully created.`;
 		}
 	);
 };
 
 /**
  * @dev This will delete the egg metadata from S3 and create a new object with the original filepath with updated stats.
- * 
+ *
  * This function is called when a user hatches their NBMon.
- * 
+ *
  * @param {*} id resembles the NBMon ID of the metadata to be created for.
  */
 const uploadGenesisHatchedMetadata = async (id) => {
+	try {
+		const paramObj = {
+			Bucket: process.env.SPACES_NAME,
+			Key: `genesisNBMon/${id}.json`,
+		};
 
-    try {
-        const paramObj = {
-            Bucket: process.env.SPACES_NAME,
-            Key: `genesisNBMon/${id}.json`
-        }
+		// gets description of genus from Moralis DB
+		const nbmon = await getGenesisNBMon(id);
+		const genus = nbmon["genus"];
+		const genusDesc = nbmon["genusDescription"];
+		const isEgg = nbmon["isEgg"];
 
-        // gets description of genus from Moralis DB
-        const nbmon = await getGenesisNBMon(id);
-        const genus = nbmon["genus"];
-        const genusDesc = nbmon["genusDescription"];
-        const isEgg = nbmon["isEgg"];
+		// first checks if `id` has been hatched before (will get saved in Hatched_Metadata DB).
+		const hatchedQuery = new Moralis.Query("Hatched_Metadata");
+		const hatchedPipeline = [
+			{ match: { nbmonId: id } },
+			{ project: { _id: 0, nbmonId: 1 } },
+		];
+		const hatchedAggRes = await hatchedQuery.aggregate(hatchedPipeline);
 
-        // first checks if `id` has been hatched before (will get saved in Hatched_Metadata DB).
-        const hatchedQuery = new Moralis.Query("Hatched_Metadata");
-        const hatchedPipeline = [
-            { match: { nbmonId: id } },
-            { project: { _id: 0, nbmonId: 1 } }
-        ];
-        const hatchedAggRes = await hatchedQuery.aggregate(hatchedPipeline);
+		// if id doesn't exist in DB (meaning that it hasn't been hatched before and stored in the DB)
+		if (hatchedAggRes.length === 0) {
+			// double check to ensure that the nbmon has been hatched (but not in the DB)
+			if (isEgg === false) {
+				// before deleting the object, checks if object exists within bucket.
+				await s3.headObject(paramObj).promise();
+				try {
+					// deletes the specified object.
+					await s3
+						.deleteObject(paramObj, (err) => {
+							if (err) throw new Error(err.stack);
+						})
+						.promise();
+				} catch (err) {
+					return err;
+				}
 
-        // if id doesn't exist in DB (meaning that it hasn't been hatched before and stored in the DB)
-        if (hatchedAggRes.length === 0) {
-            // double check to ensure that the nbmon has been hatched (but not in the DB)
-            if (isEgg === false) {
-                // before deleting the object, checks if object exists within bucket.
-                await s3.headObject(paramObj).promise();
-                try {
-                    // deletes the specified object.
-                    await s3.deleteObject(
-                        paramObj, 
-                        (err) => {
-                            if (err) throw new Error(err.stack);  
-                        }
-                    ).promise();
-                } catch (err) {
-                    return err;
-                }
+				const newMetadata = {
+					name: `NBMon #${id} - ${genus}`,
+					// gets from moralis
+					description: genusDesc,
+					image: `https://nbcompany.fra1.digitaloceanspaces.com/genesisGenera/${genus}.png`,
+					attributes: [
+						{
+							display_type: "date",
+							trait_type: "Hatched on",
+							// born on may be slightly different than the smart contract's bornAt due to the nature of the code.
+							value: nbmon["hatchedAt"],
+						},
+						{
+							trait_type: "First Type",
+							value: nbmon["types"][0],
+						},
+						{
+							trait_type: "Second Type",
+							value: nbmon["types"][1],
+						},
+						{
+							display_type: "number",
+							trait_type: "Health Potential",
+							value: nbmon["healthPotential"],
+						},
+						{
+							display_type: "number",
+							trait_type: "Energy Potential",
+							value: nbmon["energyPotential"],
+						},
+						{
+							display_type: "number",
+							trait_type: "Attack Potential",
+							value: nbmon["attackPotential"],
+						},
+						{
+							display_type: "number",
+							trait_type: "Defense Potential",
+							value: nbmon["defensePotential"],
+						},
+						{
+							display_type: "number",
+							trait_type: "Special Attack Potential",
+							value: nbmon["spAtkPotential"],
+						},
+						{
+							display_type: "number",
+							trait_type: "Special Defense Potential",
+							value: nbmon["spDefPotential"],
+						},
+						{
+							display_type: "number",
+							trait_type: "Speed Potential",
+							value: nbmon["speedPotential"],
+						},
+						{
+							trait_type: "Passive One",
+							value: nbmon["passives"][0],
+						},
+						{
+							trait_type: "Passive Two",
+							value: nbmon["passives"][1],
+						},
+					],
+				};
 
-                const newMetadata = {
-                    name: `NBMon #${id} - ${genus}`,
-                    // gets from moralis
-                    description: genusDesc,
-                    image: `https://nbcompany.fra1.digitaloceanspaces.com/genesisGenera/${genus}.png`,
-                    attributes: [
-                        {
-                            display_type: "date",
-                            trait_type: "Hatched on",
-                            // born on may be slightly different than the smart contract's bornAt due to the nature of the code.
-                            value: nbmon["hatchedAt"]
-                        },
-                        {
-                            trait_type: "First Type",
-                            value: nbmon["types"][0]
-                        },
-                        {
-                            trait_type: "Second Type",
-                            value: nbmon["types"][1]
-                        },
-                        {
-                            display_type: "number",
-                            trait_type: "Health Potential",
-                            value: nbmon["healthPotential"]
-                        },
-                        {
-                            display_type: "number",
-                            trait_type: "Energy Potential",
-                            value: nbmon["energyPotential"]
-                        },
-                        {
-                            display_type: "number",
-                            trait_type: "Attack Potential",
-                            value: nbmon["attackPotential"]
-                        },
-                        {
-                            display_type: "number",
-                            trait_type: "Defense Potential",
-                            value: nbmon["defensePotential"]
-                        },
-                        {
-                            display_type: "number",
-                            trait_type: "Special Attack Potential",
-                            value: nbmon["spAtkPotential"]
-                        },
-                        {
-                            display_type: "number",
-                            trait_type: "Special Defense Potential",
-                            value: nbmon["spDefPotential"]
-                        },
-                        {
-                            display_type: "number",
-                            trait_type: "Speed Potential",
-                            value: nbmon["speedPotential"]
-                        },
-                        {
-                            trait_type: "Passive One",
-                            value: nbmon["passives"][0]
-                        },
-                        {
-                            trait_type: "Passive Two",
-                            value: nbmon["passives"][1]
-                        }
-                    ],
-                };
+				// upload to Spaces
+				s3.putObject(
+					{
+						Bucket: process.env.SPACES_NAME,
+						Key: `genesisNBMon/${id}.json`,
+						Body: JSON.stringify(newMetadata),
+						ACL: "public-read",
+						ContentType: "application/json",
+					},
+					(err) => {
+						if (err) throw new Error(err.stack);
+						return `genesisNBMon/${id}.json has been successfully created.`;
+					}
+				);
 
-                // upload to Spaces
-                s3.putObject(
-                    {
-                        Bucket: process.env.SPACES_NAME,
-                        Key: `genesisNBMon/${id}.json`,
-                        Body: JSON.stringify(newMetadata),
-                        ACL: "public-read",
-                        ContentType: "application/json"
-                    },
-                    (err) => {
-                        if (err) throw new Error(err.stack);
-                        return `genesisNBMon/${id}.json has been successfully created.`
-                    }
-                );
+				//add to Hatched_Metadata DB
+				const Hatched_Metadata = Moralis.Object.extend("Hatched_Metadata");
+				const hatchedMetadata = new Hatched_Metadata();
 
-                //add to Hatched_Metadata DB
-                const Hatched_Metadata = Moralis.Object.extend("Hatched_Metadata");
-                const hatchedMetadata = new Hatched_Metadata();
+				hatchedMetadata.set("nbmonId", id);
 
-                hatchedMetadata.set("nbmonId", id);
-
-                hatchedMetadata.save().then((metadata) => {
-                    return `Metadata ${metadata} added with NBMon ID ${id}`;
-                }, (err) => {
-                    throw new Error(err.stack);
-                });
-            } else {
-                return "isEgg is still true. Please double check again."
-            }
-        } else {
-            return "Egg has already been hatched. Upload metadata to Spaces failed."
-        }
-    } catch (err) {
-        return err;
-    }
+				hatchedMetadata.save().then(
+					(metadata) => {
+						return `Metadata ${metadata} added with NBMon ID ${id}`;
+					},
+					(err) => {
+						throw new Error(err.stack);
+					}
+				);
+			} else {
+				return "isEgg is still true. Please double check again.";
+			}
+		} else {
+			return "Egg has already been hatched. Upload metadata to Spaces failed.";
+		}
+	} catch (err) {
+		return err;
+	}
 };
 
 module.exports = {
 	uploadGenesisEggMetadata,
-    uploadGenesisHatchedMetadata
+	uploadGenesisHatchedMetadata,
 };

--- a/logic/genesisNBMonLogic.js
+++ b/logic/genesisNBMonLogic.js
@@ -9,7 +9,10 @@ const moralisAPINode = process.env.MORALIS_APINODE;
 const nodeURL = `https://speedy-nodes-nyc.moralis.io/${moralisAPINode}/eth/rinkeby`;
 const customHttpProvider = new ethers.providers.JsonRpcProvider(nodeURL);
 
-const { getAttackEffectiveness, getDefenseEffectiveness } = require("../logic/typeEffectivenessLogic");
+const {
+	getAttackEffectiveness,
+	getDefenseEffectiveness,
+} = require("../logic/typeEffectivenessLogic");
 const genesisNBMonABI = fs.readFileSync(
 	path.resolve(__dirname, "../abi/genesisNBMon.json")
 );
@@ -50,8 +53,16 @@ const getGenesisNBMon = async (id) => {
 		const firstType = nbmon[6][0] === undefined ? null : nbmon[6][0];
 		const secondType = nbmon[6][1] === undefined ? null : nbmon[6][1];
 		// calculates typeEffectiveness
-		const attackEff = await getAttackEffectiveness(firstType, secondType, "true");
-		const defenseEff = await getDefenseEffectiveness(firstType, secondType, "true");
+		const attackEff = await getAttackEffectiveness(
+			firstType,
+			secondType,
+			"true"
+		);
+		const defenseEff = await getDefenseEffectiveness(
+			firstType,
+			secondType,
+			"true"
+		);
 		nbmonObj["strongAgainst"] = attackEff["Strong against"];
 		nbmonObj["weakAgainst"] = attackEff["Weak against"];
 		nbmonObj["resistantTo"] = defenseEff["Resistant to"];
@@ -69,21 +80,27 @@ const getGenesisNBMon = async (id) => {
 		if (nbmon[9] === true) {
 			nbmonObj["mutation"] = "Not mutated";
 			nbmonObj["mutationType"] = null;
-		// if already hatched
+			// if already hatched
 		} else {
-			nbmonObj["mutation"] = nbmon[5][2] === "Not mutated" ? nbmon[5][2] : "Mutated";
-			nbmonObj["mutationType"] = nbmonObj["mutation"] === "Mutated" ? nbmon[5][2] : null;
+			nbmonObj["mutation"] =
+				nbmon[5][2] === "Not mutated" ? nbmon[5][2] : "Mutated";
+			nbmonObj["mutationType"] =
+				nbmonObj["mutation"] === "Mutated" ? nbmon[5][2] : null;
 		}
 
 		nbmonObj["species"] = nbmon[5][3] === undefined ? null : nbmon[5][3];
 		nbmonObj["genus"] = nbmon[5][4] === undefined ? null : nbmon[5][4];
-		nbmonObj["genusDescription"] = await getGenesisGenusDescription(nbmonObj["genus"]);
+		nbmonObj["genusDescription"] = await getGenesisGenusDescription(
+			nbmonObj["genus"]
+		);
 		nbmonObj["behavior"] = await getGenesisBehavior(nbmonObj["genus"]);
 
 		// calculation for fertility
 		nbmonObj["fertility"] = nbmon[5][5] === undefined ? null : nbmon[5][5];
 		if (nbmon[5][1] !== undefined) {
-			nbmonObj["fertilityDeduction"] = await getGenesisFertilityDeduction(nbmon[5][1]);
+			nbmonObj["fertilityDeduction"] = await getGenesisFertilityDeduction(
+				nbmon[5][1]
+			);
 		} else {
 			nbmonObj["fertilityDeduction"] = null;
 		}
@@ -148,13 +165,12 @@ const getGenesisNBMonTypes = async (genusParam) => {
 
 		const typesPipeline = [
 			{ match: { Genus: genusParam } },
-			{ project: { _id: 0, Types: 1 } }
+			{ project: { _id: 0, Types: 1 } },
 		];
 
 		const typesAggRes = await typesQuery.aggregate(typesPipeline);
 
 		return typesAggRes[0]["Types"];
-
 	} catch (err) {
 		return err;
 	}
@@ -162,12 +178,12 @@ const getGenesisNBMonTypes = async (genusParam) => {
 
 const getGenesisGenusDescription = async (genusParam) => {
 	try {
-		if (genusParam !==  null) {
+		if (genusParam !== null) {
 			const descQuery = new Moralis.Query("NBMon_Data");
 
 			const descPipeline = [
 				{ match: { Genus: genusParam } },
-				{ project: { _id: 0, Description: 1 } }
+				{ project: { _id: 0, Description: 1 } },
 			];
 
 			const descAggRes = await descQuery.aggregate(descPipeline);
@@ -178,7 +194,7 @@ const getGenesisGenusDescription = async (genusParam) => {
 	} catch (err) {
 		return err;
 	}
-}
+};
 
 const getGenesisBehavior = async (genusParam) => {
 	try {
@@ -187,7 +203,7 @@ const getGenesisBehavior = async (genusParam) => {
 
 			const behaviorPipeline = [
 				{ match: { Genus: genusParam } },
-				{ project: { _id: 0, Behavior: 1 } }
+				{ project: { _id: 0, Behavior: 1 } },
 			];
 
 			const behaviorAggRes = await behaviorQuery.aggregate(behaviorPipeline);
@@ -198,7 +214,7 @@ const getGenesisBehavior = async (genusParam) => {
 	} catch (err) {
 		return err;
 	}
-}
+};
 
 const getGenesisFertilityDeduction = async (rarity) => {
 	try {
@@ -224,7 +240,9 @@ const getGenesisFertilityDeduction = async (rarity) => {
 const generalConfig = async () => {
 	try {
 		const supplyLimit = 5000; // total number of NBMons that can be minted
-		const haveBeenMinted = parseInt(Number(await genesisContract.totalSupply())); // total number of NBMons that have been minted
+		const haveBeenMinted = parseInt(
+			Number(await genesisContract.totalSupply())
+		); // total number of NBMons that have been minted
 		const now = moment().unix();
 		const publicOpenAt = parseInt(process.env.PUBLIC_MINT_TIME_UNIX);
 		const whitelistOpenAt = parseInt(process.env.WHITELIST_MINT_TIME_UNIX);
@@ -254,7 +272,8 @@ const generalConfig = async () => {
 const config = async (address) => {
 	try {
 		const generalConfigs = await generalConfig();
-		const { isWhitelistOpen, isPublicOpen } = generalConfigs.timeStamps;
+		const { isWhitelistOpen, isPublicOpen, isMintingEnded } =
+			generalConfigs.timeStamps;
 		const { haveBeenMinted, supplyLimit } = generalConfigs.supplies;
 		const isWhitelisted = await genesisContract.whitelisted(address);
 
@@ -263,22 +282,64 @@ const config = async (address) => {
 		const hasMintedFive = amountMinted === 5 ? true : false;
 		let canMint = false;
 
-		if (haveBeenMinted < supplyLimit) {
-			if (isWhitelisted) {
-				if (isWhitelistOpen && !hasMintedFive) canMint = true;
-				else canMint = false;
-			} else {
-				if (isPublicOpen && !hasMintedFive) canMint = true;
-				else canMint = false;
+		if (hasMintedFive || isMintingEnded) canMint = false;
+		else {
+			if (haveBeenMinted < supplyLimit) {
+				//If user is whitelisted
+				if (isWhitelisted) {
+					canMint = canMintUserWhitelisted(
+						isWhitelistOpen,
+						isPublicOpen,
+						amountMinted,
+						hasMintedFive
+					);
+
+					//If user isn't whitelisted
+				} else {
+					if (isPublicOpen && !hasMintedFive) canMint = true;
+					else canMint = false;
+				}
 			}
 		}
 
-		const status = { address, canMint, isWhitelisted, amountMinted, hasMintedFive };
+		const status = {
+			address,
+			canMint,
+			isWhitelisted,
+			amountMinted,
+			hasMintedFive,
+		};
 
 		return { status, ...generalConfigs };
 	} catch (err) {
 		return err;
 	}
+};
+
+/**
+ * @dev Decides canMint value (bool) of a whitelisted user
+ */
+const canMintUserWhitelisted = (
+	isWhitelistOpen,
+	isPublicOpen,
+	amountMinted,
+	hasMintedFive
+) => {
+	//If whitelist minting is still closed
+	if (!isWhitelistOpen) return false;
+
+	//If user hasnt minted yet and public is closed
+	if (amountMinted === 0 && !isPublicOpen) return true;
+
+	//If user has minted once and public is closed
+	if (amountMinted === 1 && !isPublicOpen) return false;
+
+	//If user hasnt minted 5 and public is open
+	if (!hasMintedFive && isPublicOpen) return true;
+
+	//Otherwise,
+	//(this is most likely will never be called)
+	return false;
 };
 
 module.exports = {
@@ -290,5 +351,5 @@ module.exports = {
 	getGenesisNBMonTypes,
 	getGenesisFertilityDeduction,
 	getGenesisGenusDescription,
-	getGenesisBehavior
+	getGenesisBehavior,
 };

--- a/logic/genesisNBMonMintingLogic.js
+++ b/logic/genesisNBMonMintingLogic.js
@@ -82,7 +82,7 @@ const publicMint = async (address) => {
 
 		let owner = address;
 		let amountToMint = 1;
-		let hatchingDuration = 300	;
+		let hatchingDuration = 300;
 		let nbmonStats = [];
 		let types = [];
 		let potential = [];
@@ -128,7 +128,9 @@ const publicMint = async (address) => {
 		const currentCount = await genesisContract.currentGenesisNBMonCount();
 		// just to be extra safe
 		const mintedId = parseInt(currentCount) - 1;
-
+		if (!mintedId || mintedId === undefined || isNaN(mintedId)) {
+			console.log("Error nbmonId", mintedId);
+		}
 		//add metadata of the egg to Spaces
 		uploadGenesisEggMetadata(mintedId, hatchingDuration);
 
@@ -138,7 +140,7 @@ const publicMint = async (address) => {
 	}
 };
 
-module.exports = { 
-	whitelistedMint, 
-	publicMint 
+module.exports = {
+	whitelistedMint,
+	publicMint,
 };


### PR DESCRIPTION
This PR is mostly about implementing new logic in /config for the new minting policy (5 nbmons per user instead of the old 1 nbmon per user).

The code now returns the correct canMint value for /config/:address route for all possible conditions imaginable. See method `config()` for more information.

Other changes are mostly just logging to better track error if it ever happens (we're still trying to squash the undefined nbmonId bug), and other changes are just auto-formatter from my editor. 

About the console.logs, I'm placing more of them so whenever that weird bug happens, we can go to heroku (or our backend, wherever it happened really) n see the logs and actually see what was not working. Is it uploading to s3? Is it actually the nbmonId?

Thanks. :)