### PR TITLE
Fixed Typo HatchingSignatures

### DIFF
--- a/logic/activitiesLogic.js
+++ b/logic/activitiesLogic.js
@@ -215,7 +215,7 @@ const checkHatchingSignatureValid = async (hash) => {
  * This is to make sure that no same activity can be added twice
  */
 const invalidateHatchingSignature = async (signature) => {
-	const hatchingSignatures = Moralis.Object.extend("HatchingSignature");
+	const hatchingSignatures = Moralis.Object.extend("HatchingSignatures");
 	const hatchingSignatureQuery = new Moralis.Query(hatchingSignatures);
 
 	hatchingSignatureQuery.equalTo("signature", signature);


### PR DESCRIPTION
Typo caused caused an error while adding hatching activity for a user. Not actually when adding it (it still adds to the user just fine), but after adding it to an activity, it's supposed to change a value inside **HatchingSignatures** class (moralis) for security / data authenticity purpose, but I wrote **HatchingSignature**  (the typo) so the value never changed.