### PR TITLE
Better handle error in some endpoints to prevent server crashing

### DIFF
--- a/logic/genesisNBMonLogic.js
+++ b/logic/genesisNBMonLogic.js
@@ -178,7 +178,7 @@ const getGenesisNBMon = async (id) => {
 
 		return nbmonObj;
 	} catch (err) {
-		throw new Error(err.stack);
+		throw err;
 	}
 };
 
@@ -192,7 +192,7 @@ const getOwnerGenesisNBMonIDs = async (address) => {
 		}
 		return convertedArray;
 	} catch (err) {
-		throw new Error(err.stack);
+		throw err;
 	}
 };
 
@@ -211,7 +211,7 @@ const getOwnerGenesisNBMons = async (address) => {
 
 		return nbmons;
 	} catch (err) {
-		throw new Error(err.stack);
+		throw err;
 	}
 };
 
@@ -228,7 +228,7 @@ const getGenesisNBMonTypes = async (genusParam) => {
 		return typesAggRes[0]["Types"];
 		// console.log(typesAggRes[0]["Types"][0]);
 	} catch (err) {
-		throw new Error(err.stack);
+		throw err;
 	}
 };
 
@@ -321,7 +321,7 @@ const generalConfig = async () => {
 
 		return { timeStamps, supplies };
 	} catch (err) {
-		return err;
+		throw err;
 	}
 };
 
@@ -385,7 +385,7 @@ const config = async (address) => {
 
 		return { status, ...generalConfigs };
 	} catch (err) {
-		return err;
+		throw err;
 	}
 };
 

--- a/routes/genesisNBMon.js
+++ b/routes/genesisNBMon.js
@@ -2,50 +2,81 @@ const express = require("express");
 const router = express.Router();
 
 const genesisLogic = require("../logic/genesisNBMonLogic");
+const httpErrorStatusCode = require("../utils/httpErrorStatusCode");
 
 router.get("/getGenesisNBMon/:id", async (req, res) => {
-	let id = req.params.id;
-	let nbmon = await genesisLogic
-		.getGenesisNBMon(id)
-		.catch((err) => res.json(err.message));
-	res.json(nbmon);
+	try {
+		let id = req.params.id;
+		let nbmon = await genesisLogic.getGenesisNBMon(id).catch((err) => {
+			throw err;
+		});
+		res.json(nbmon);
+	} catch (error) {
+		res.status(httpErrorStatusCode(error.code)).json({ error });
+	}
 });
 
 router.get("/getOwnerGenesisNBMonIDs/:address", async (req, res) => {
-	let address = req.params.address;
-	let ownerIds = await genesisLogic
-		.getOwnerGenesisNBMonIDs(address)
-		.catch((err) => res.json(err.message));
-	res.json(ownerIds);
+	try {
+		let address = req.params.address;
+		let ownerIds = await genesisLogic
+			.getOwnerGenesisNBMonIDs(address)
+			.catch((err) => {
+				throw err;
+			});
+		res.json(ownerIds);
+	} catch (error) {
+		res.status(httpErrorStatusCode(error.code)).json({ error });
+	}
 });
 
 router.get("/getOwnerGenesisNBMons/:address", async (req, res) => {
-	let address = req.params.address;
-	let nbmons = await genesisLogic
-		.getOwnerGenesisNBMons(address)
-		.catch((err) => res.json(err.message));
-	res.json(nbmons);
+	try {
+		let address = req.params.address;
+		let nbmons = await genesisLogic
+			.getOwnerGenesisNBMons(address)
+			.catch((err) => {
+				throw err;
+			});
+		res.json(nbmons);
+	} catch (error) {
+		res.status(httpErrorStatusCode(error.code)).json({ error });
+	}
 });
 
 router.get("/config/:address", async (req, res) => {
-	let address = req.params.address;
-	let config = await genesisLogic
-		.config(address)
-		.catch((err) => res.json(err.message));
-	res.json(config);
+	try {
+		let address = req.params.address;
+		let config = await genesisLogic.config(address).catch((err) => {
+			throw err;
+		});
+		res.json(config);
+	} catch (error) {
+		res.status(httpErrorStatusCode(error.code)).json({ error });
+	}
 });
 
 router.get("/config", async (_, res) => {
-	let config = await genesisLogic
-		.generalConfig()
-		.catch((err) => res.json(err.message));
-	res.json(config);
+	try {
+		let config = await genesisLogic.generalConfig().catch((err) => {
+			throw err;
+		});
+		res.json(config);
+	} catch (error) {
+		res.status(httpErrorStatusCode(error.code)).json({ error });
+	}
 });
 
 router.get("/getTypes/:genus", async (req, res) => {
-	let genus = req.params.genus;
-	let types = await genesisLogic.getGenesisNBMonTypes(genus).catch((err) => res.json(err));
-	res.json(types);
+	try {
+		let genus = req.params.genus;
+		let types = await genesisLogic.getGenesisNBMonTypes(genus).catch((err) => {
+			throw err;
+		});
+		res.json(types);
+	} catch (error) {
+		res.status(httpErrorStatusCode(error.code)).json({ error });
+	}
 });
 
 module.exports = router;

--- a/utils/httpErrorStatusCode.js
+++ b/utils/httpErrorStatusCode.js
@@ -1,0 +1,14 @@
+const ERROR_CODE_TO_STATUS_CODE_MAP = {
+	INVALID_ARGUMENT: 400, // Invalid Request
+	CALL_EXCEPTION: 404, // Resource can't be found
+	DEFAULT: 500, // Internal server error
+};
+
+const httpErrorStatusCode = (errorCode = "DEFAULT") => {
+	if (!(errorCode in ERROR_CODE_TO_STATUS_CODE_MAP)) {
+		errorCode = "DEFAULT";
+	}
+	return ERROR_CODE_TO_STATUS_CODE_MAP[errorCode];
+};
+
+module.exports = httpErrorStatusCode;


### PR DESCRIPTION
I noticed an issue when trying to access `getOwnerGenesisNBMons/address` and `getGenesisNBMon/id`. When address or id don't exist, **the whole server crashes instead of throwing a proper error**. After some investigation, this is caused by the way we handle errors in those endpoints. This is a "bug" that needs urgent fixing.

The PR's intention is to better handle the errors. This results in our app being more more resilient (doesn't just randomly crash) when an error is being thrown. Instead, our app will return the error with the proper status code which should've always been the case since the start. :)